### PR TITLE
Add Docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Book Appointment System
+
+This repository contains a Spring Boot backend and a React frontend. Docker files and a compose configuration are provided to simplify local deployment.
+
+## Requirements
+- Docker
+- Docker Compose
+
+## Usage
+Build and start all services:
+```bash
+docker compose up --build
+```
+The frontend will be available at [http://localhost:3000](http://localhost:3000) and the backend API at [http://localhost:9192](http://localhost:9192).

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,4 @@
+.git
+mvnw
+mvnw.cmd
+target

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+# Use Maven to build the application
+FROM maven:3.9.7-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn package -DskipTests
+
+# Use a smaller JRE image to run the app
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 9192
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.8"
+services:
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: Liminghao2001
+      MYSQL_DATABASE: pet-care-system
+    ports:
+      - "3306:3306"
+
+  backend:
+    build: ./backend
+    ports:
+      - "9192:9192"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/pet-care-system
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: Liminghao2001
+    depends_on:
+      - db
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend


### PR DESCRIPTION
## Summary
- add Dockerfile for backend
- add backend `.dockerignore`
- compose services for backend, frontend and MySQL
- document Docker usage in new README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9be22824832eb51b14972e6da947