### PR TITLE
fix: improve login error handling and base url configuration

### DIFF
--- a/backend/src/main/java/com/dailycodework/universalpetcare/security/config/ApplicationSecurityConfig.java
+++ b/backend/src/main/java/com/dailycodework/universalpetcare/security/config/ApplicationSecurityConfig.java
@@ -58,12 +58,15 @@ public class ApplicationSecurityConfig {
 
     /**
      * Centralized CORS configuration allowing both the deployed frontend and local
-     * development origin.
+     * development origins (Vite and React scripts).
      */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://34.246.135.101:3000", "http://localhost:5174"));
+        configuration.setAllowedOrigins(List.of(
+                "http://34.246.135.101:3000",
+                "http://localhost:5174",
+                "http://localhost:3000"));
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/frontend/src/__test__/components/utils/api.test.js
+++ b/frontend/src/__test__/components/utils/api.test.js
@@ -1,5 +1,5 @@
 import { api } from '../../../components/utils/api.js';
 
 test('api instance has correct baseURL', () => {
-  expect(api.defaults.baseURL).toBe('http://34.246.135.101:9192/api/v1');
+  expect(api.defaults.baseURL).toBe('http://localhost:9192/api/v1');
 });

--- a/frontend/src/components/auth/Login.jsx
+++ b/frontend/src/components/auth/Login.jsx
@@ -60,8 +60,11 @@ const Login = () => {
       clearLoginForm();
       navigate(from, { replace: true });
       window.location.reload();
-    } catch (error) {    
-      setErrorMessage(error.response.data.message);
+    } catch (error) {
+      const message =
+        error.response?.data?.message ||
+        "Unable to reach server. Please try again later.";
+      setErrorMessage(message);
       setShowErrorAlert(true);
     }
   };

--- a/frontend/src/components/utils/api.js
+++ b/frontend/src/components/utils/api.js
@@ -1,5 +1,10 @@
 import axios from "axios";
 
+// Determine the base URL for API requests. The value can be overridden
+// using the `VITE_API_BASE_URL` environment variable; otherwise, it falls
+// back to the local development server.
+const baseURL = process.env.VITE_API_BASE_URL || "http://localhost:9192/api/v1";
+
 export const api = axios.create({
-  baseURL: "http://34.246.135.101:9192/api/v1",
+  baseURL,
 });


### PR DESCRIPTION
## Summary
- make API base URL configurable with VITE_API_BASE_URL env var
- handle login network errors gracefully with fallback message
- update API unit test for new default base URL

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a083cd827c832e9e97dc8e078c96e3