### PR TITLE
Fix Docker API port mapping and frontend configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
         condition: service_healthy
     ports:
       - "9192:9192"
+      - "9193:9192"
     environment:
       # Database configuration
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/pet-care-system?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
@@ -83,7 +84,7 @@ services:
     ports:
       - "3000:80"
     environment:
-      - REACT_APP_API_BASE_URL=http://localhost:9192/api/v1
+      - VITE_API_BASE_URL=http://localhost:9193/api/v1
     networks:
       - pet-care-network
 

--- a/frontend/src/__test__/components/utils/api.test.js
+++ b/frontend/src/__test__/components/utils/api.test.js
@@ -1,5 +1,19 @@
-import { api } from '../../../components/utils/api.js';
+describe('api base URL resolution', () => {
+  afterEach(() => {
+    delete process.env.VITE_API_BASE_URL;
+    jest.resetModules();
+  });
 
-test('api instance has correct baseURL', () => {
-  expect(api.defaults.baseURL).toBe('http://localhost:9192/api/v1');
+  test('falls back to default baseURL when env var is missing', async () => {
+    const { api, resolveApiBaseUrl } = await import('../../../components/utils/api.js');
+    expect(resolveApiBaseUrl()).toBe('http://localhost:9192/api/v1');
+    expect(api.defaults.baseURL).toBe('http://localhost:9192/api/v1');
+  });
+
+  test('uses VITE_API_BASE_URL when provided', async () => {
+    process.env.VITE_API_BASE_URL = 'http://localhost:9193/api/v1';
+    const { api, resolveApiBaseUrl } = await import('../../../components/utils/api.js');
+    expect(resolveApiBaseUrl()).toBe('http://localhost:9193/api/v1');
+    expect(api.defaults.baseURL).toBe('http://localhost:9193/api/v1');
+  });
 });

--- a/frontend/src/components/utils/api.js
+++ b/frontend/src/components/utils/api.js
@@ -1,5 +1,29 @@
+/* global __VITE_API_BASE_URL__ */
 import axios from "axios";
 
+const FALLBACK_BASE_URL = "http://localhost:9192/api/v1";
+
+const readConfiguredBaseUrl = () => {
+  if (
+    typeof __VITE_API_BASE_URL__ !== "undefined" &&
+    typeof __VITE_API_BASE_URL__ === "string" &&
+    __VITE_API_BASE_URL__.trim().length > 0
+  ) {
+    return __VITE_API_BASE_URL__.trim();
+  }
+
+  if (typeof process !== "undefined") {
+    const processBaseUrl = process.env?.VITE_API_BASE_URL;
+    if (processBaseUrl && processBaseUrl.trim().length > 0) {
+      return processBaseUrl.trim();
+    }
+  }
+
+  return undefined;
+};
+
+export const resolveApiBaseUrl = () => readConfiguredBaseUrl() ?? FALLBACK_BASE_URL;
+
 export const api = axios.create({
-  baseURL: "http://localhost:9192/api/v1",
+  baseURL: resolveApiBaseUrl(),
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    plugins: [react()],
+    define: {
+      __VITE_API_BASE_URL__: JSON.stringify(env.VITE_API_BASE_URL ?? ''),
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- map host port 9193 to the backend container and provide a Vite-compatible API base URL env variable
- let the frontend API client resolve its base URL from Vite/Node env variables with a sensible default
- adjust the Vite build config and accompanying tests to cover the new base URL resolution logic

## Testing
- npm test -- src/__test__/components/utils/api.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d6f9116800832e9c105ed7b67091cf