### PR TITLE
Update frontend API base URL fallback handling

### DIFF
--- a/frontend/src/__test__/components/utils/api.test.js
+++ b/frontend/src/__test__/components/utils/api.test.js
@@ -1,5 +1,10 @@
-import { api } from '../../../components/utils/api.js';
+import {
+  api,
+  API_BASE_URL,
+  FALLBACK_API_BASE_URL,
+} from '../../../components/utils/api.js';
 
 test('api instance has correct baseURL', () => {
-  expect(api.defaults.baseURL).toBe('http://localhost:9192/api/v1');
+  expect(API_BASE_URL).toBe(FALLBACK_API_BASE_URL);
+  expect(api.defaults.baseURL).toBe(FALLBACK_API_BASE_URL);
 });

--- a/frontend/src/components/utils/api.js
+++ b/frontend/src/components/utils/api.js
@@ -1,5 +1,12 @@
 import axios from "axios";
 
+export const FALLBACK_API_BASE_URL = "http://localhost:9192/api/v1";
+
+const reactApiBaseUrl =
+  typeof process !== "undefined" ? process.env?.REACT_APP_API_BASE_URL : undefined;
+
+export const API_BASE_URL = reactApiBaseUrl ?? FALLBACK_API_BASE_URL;
+
 export const api = axios.create({
-  baseURL: "http://localhost:9192/api/v1",
+  baseURL: API_BASE_URL,
 });


### PR DESCRIPTION
## Summary
- default the shared axios client to a fallback API base URL of http://localhost:9192/api/v1 while preserving support for process-based overrides
- export the base URL constants so they can be reused and update the existing unit test to assert the new fallback behavior

## Testing
- npm test -- --runTestsByPath src/__test__/components/utils/api.test.js
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d6fb75a02c832eb226c2fd7d1903aa